### PR TITLE
Fix polls issue with router["results"].url -> url_for

### DIFF
--- a/demos/polls/aiohttpdemo_polls/views.py
+++ b/demos/polls/aiohttpdemo_polls/views.py
@@ -59,5 +59,5 @@ async def vote(request):
         except db.RecordNotFound as e:
             raise web.HTTPNotFound(text=str(e))
         router = request.app.router
-        url = router['results'].url(parts={'question_id': question_id})
+        url = router['results'].url_for(question_id=str(question_id))
         return web.HTTPFound(location=url)


### PR DESCRIPTION
polls demo was failing on `router["results"].url` when vote was sent.

This is fixing it.