### PR TITLE
Swap for loop with list comprehension.

### DIFF
--- a/demos/imagetagger/imagetagger/worker.py
+++ b/demos/imagetagger/imagetagger/worker.py
@@ -55,7 +55,7 @@ def predict(raw_data: bytes, model: Optional[Any]=None) -> bytes:
 
     # loop over the results and add them to the list of
     # returned predictions
-    data['predictions'] = [{'label': label, 'probability': float(prob)} 
+    data['predictions'] = [{'label': label, 'probability': float(prob)}
                            for _, label, prob in results[0]]
 
     data['success'] = True

--- a/demos/imagetagger/imagetagger/worker.py
+++ b/demos/imagetagger/imagetagger/worker.py
@@ -52,10 +52,11 @@ def predict(raw_data: bytes, model: Optional[Any]=None) -> bytes:
 
     preds = model.predict(image)
     results = imagenet_utils.decode_predictions(preds)
-    
+
     # loop over the results and add them to the list of
     # returned predictions
-    data['predictions'] = [{'label': label, 'probability': float(prob)} for _, label, prob in results[0]]
+    data['predictions'] = [{'label': label, 'probability': float(prob)} 
+                           for _, label, prob in results[0]]
 
     data['success'] = True
     return json.dumps(data).encode('utf-8')

--- a/demos/imagetagger/imagetagger/worker.py
+++ b/demos/imagetagger/imagetagger/worker.py
@@ -52,13 +52,10 @@ def predict(raw_data: bytes, model: Optional[Any]=None) -> bytes:
 
     preds = model.predict(image)
     results = imagenet_utils.decode_predictions(preds)
-    data['predictions'] = []
-
+    
     # loop over the results and add them to the list of
     # returned predictions
-    for _, label, prob in results[0]:
-        r = {'label': label, 'probability': float(prob)}
-        data['predictions'].append(r)
+    data['predictions'] = [{'label': label, 'probability': float(prob)} for _, label, prob in results[0]]
 
     data['success'] = True
     return json.dumps(data).encode('utf-8')


### PR DESCRIPTION
Usually, list comprehensions are faster to execute than for loops. Especially in Python 3.x, where it returns a generator and not the whole list.
It might be a bit more obscure to read, but it is more efficient speed-wise, which might be a concern when doing real-time predictions.
Plus, it allows you to skip an empty assignment, which is another slight speed gain.