### PR TITLE
Fix status codes on error handlers

### DIFF
--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -4,11 +4,15 @@ from aiohttp import web
 
 
 async def handle_404(request):
-    return aiohttp_jinja2.render_template('404.html', request, {})
+    resp = aiohttp_jinja2.render_template('404.html', request, {})
+    resp.set_status(404)
+    return resp
 
 
 async def handle_500(request):
-    return aiohttp_jinja2.render_template('500.html', request, {})
+    resp = aiohttp_jinja2.render_template('500.html', request, {})
+    resp.set_status(500)
+    return resp
 
 
 def create_error_middleware(overrides):


### PR DESCRIPTION
The demo provides custom 404/500 pages. However, it also makes the mistake of changing the return codes to 200 OK, which is probably not what is wanted in most cases.

This sets the correct status codes.

An alternative approach is in #112 . Either way is fine with me.