### PR TITLE
Better handling of overrides.

### DIFF
--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -25,7 +25,7 @@ def create_error_middleware(overrides):
                 return resp
 
             raise
-        except:
+        except:  # noqa: E722
             resp = await overrides[500](request)
             resp.set_status(500)
             return resp

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -23,7 +23,7 @@ def create_error_middleware(overrides):
                 return await override(request)
 
             raise
-        except:  # noqa: E722
+        except BaseException:
             resp = await overrides[500](request)
             resp.set_status(500)
             return resp

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -15,22 +15,18 @@ def create_error_middleware(overrides):
 
     @web.middleware
     async def error_middleware(request, handler):
-
         try:
-            response = await handler(request)
-
-            override = overrides.get(response.status)
-            if override:
-                return await override(request)
-
-            return response
-
+            return await handler(request)
         except web.HTTPException as ex:
             override = overrides.get(ex.status)
             if override:
-                return await override(request)
+                resp = await override(request)
+                resp.set_status(ex.status)
+                return resp
 
             raise
+        except:
+            return await overrides[500](request)
 
     return error_middleware
 

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -26,7 +26,9 @@ def create_error_middleware(overrides):
 
             raise
         except:
-            return await overrides[500](request)
+            resp = await overrides[500](request)
+            resp.set_status(500)
+            return resp
 
     return error_middleware
 

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -23,7 +23,7 @@ def create_error_middleware(overrides):
                 return await override(request)
 
             raise
-        except BaseException:
+        except Exception:
             resp = await overrides[500](request)
             resp.set_status(500)
             return resp

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -20,9 +20,7 @@ def create_error_middleware(overrides):
         except web.HTTPException as ex:
             override = overrides.get(ex.status)
             if override:
-                resp = await override(request)
-                resp.set_status(ex.status)
-                return resp
+                return await override(request)
 
             raise
         except:  # noqa: E722


### PR DESCRIPTION
First half is to remove overrides when there is no exception.
I can see in the documentation that returning exceptions is deprecated, so if that's the reason this override exists, then we should remove it to match best practices.
If a handler returns web.Response(status=500), then they are probably already providing custom content, so overriding it here is not desired. For example, this override breaks debugtoolbar, removing it allows debugtoolbar to work correctly.

Last half is to catch any other exception and return a 500 page.

Together this results in correct behaviour when using debugtoolbar. i.e. If developing locally, any error will load the debugtoolbar page, when running in production all errors load the 500 override. The 404 override continues to work in both cases.