### PR TITLE
Remove redundant set_status

### DIFF
--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -24,7 +24,7 @@ def create_error_middleware(overrides):
 
             raise
         except Exception:
-            return overrides[500](request)
+            return await overrides[500](request)
 
     return error_middleware
 

--- a/demos/polls/aiohttpdemo_polls/middlewares.py
+++ b/demos/polls/aiohttpdemo_polls/middlewares.py
@@ -24,9 +24,7 @@ def create_error_middleware(overrides):
 
             raise
         except Exception:
-            resp = await overrides[500](request)
-            resp.set_status(500)
-            return resp
+            return overrides[500](request)
 
     return error_middleware
 


### PR DESCRIPTION
The status is now set in the handler (line 11) due to another PR, so this extra step is no longer needed.