### PR TITLE
Migrate from aioslacker to python-slack-sdk

### DIFF
--- a/demos/moderator_bot/README.md
+++ b/demos/moderator_bot/README.md
@@ -10,7 +10,7 @@ Model reused from [Moderator AI](https://github.com/aio-libs/aiohttp-demos/tree/
 
 ## Requirements
  - [aiohttp](https://github.com/aio-libs/aiohttp)
- - [aioslacker](https://github.com/aio-libs/aioslacker)
+ - [slack_sdk](https://github.com/slackapi/python-slack-sdk)
 
 
 ## Prerequisites

--- a/demos/moderator_bot/moderator_bot/handlers.py
+++ b/demos/moderator_bot/moderator_bot/handlers.py
@@ -36,8 +36,8 @@ class MainHandler:
         text = (f"Hey <@{event['user']}>, please be polite! "
                 f"Here is a funny cat GIF for you {image_url}")
 
-        await self.slack_client.chat.post_message(
-            event["channel"],
+        await self.slack_client.chat_postMessage(
+            channel=event["channel"],
             text=text,
         )
 

--- a/demos/moderator_bot/moderator_bot/server.py
+++ b/demos/moderator_bot/moderator_bot/server.py
@@ -4,7 +4,7 @@ from functools import partial
 from pathlib import Path
 
 from aiohttp import web
-from aioslacker import Slacker
+from slack_sdk.web.async_client import AsyncWebClient
 
 from .giphy import GiphyClient
 from .handlers import MainHandler
@@ -38,7 +38,7 @@ async def init_application(config):
 
     executor = ProcessPoolExecutor(MAX_WORKERS)
 
-    slack_client = Slacker(SLACK_BOT_TOKEN)
+    slack_client = AsyncWebClient(SLACK_BOT_TOKEN)
     giphy_client = GiphyClient(GIPHY_API_KEY, config["request_timeout"])
 
     handler = MainHandler(executor, slack_client, giphy_client)
@@ -55,7 +55,6 @@ async def init_application(config):
 
     app.on_cleanup.append(setup_cleanup_hooks([
         partial(executor.shutdown, wait=True),
-        slack_client.close,
         giphy_client.close,
     ]))
 

--- a/demos/moderator_bot/requirements-dev.txt
+++ b/demos/moderator_bot/requirements-dev.txt
@@ -1,6 +1,5 @@
 -i https://pypi.org/simple/
 aiohttp==3.11.7
-aioslacker==0.0.11
 async-timeout==5.0.1
 atomicwrites==1.4.1
 attrs==24.2.0
@@ -19,7 +18,7 @@ pyyaml==6.0.2
 scikit-learn==1.5.2
 scipy==1.13.1
 six==1.16.0
-slacker==0.9.42
+slack_sdk==3.33.4
 urllib3==2.2.3
 yarl==1.18.0
 zipp==3.21.0


### PR DESCRIPTION
## What do these changes do?

Replace aioslacker with [python-slack-sdk](https://github.com/slackapi/python-slack-sdk) in moderator_bot.

## Are there changes in behavior for the user?

## Related issue number

Fixes #198 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
