### PR TITLE
Remove jQuery from chat demo

### DIFF
--- a/demos/chat/aiohttpdemo_chat/templates/index.html
+++ b/demos/chat/aiohttpdemo_chat/templates/index.html
@@ -2,18 +2,23 @@
 <meta charset="utf-8" />
 <html>
   <head>
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js">
-    </script>
     <script language="javascript" type="text/javascript">
-     $(function() {
+     document.addEventListener('DOMContentLoaded', function() {
        var conn = null;
        var name = "UNKNOWN";
+       var status = document.getElementById('status');
+       var connectButton = document.getElementById('connect');
+       var sendButton = document.getElementById('send');
+       var nameLabel = document.getElementById('name');
+       var textInput = document.getElementById('text');
+       var logControl = document.getElementById('log');
+
        function log(msg) {
-         var control = $('#log');
          var date = new Date();
          var date_prompt = '(' + date.toISOString().split('T')[1].slice(0,8) + ') ';
-         control.html(control.html() + date_prompt + msg + '<br/>');
-         control.scrollTop(control.scrollTop() + 1000);
+         logControl.appendChild(document.createTextNode(date_prompt + msg));
+         logControl.appendChild(document.createElement('br'));
+         logControl.scrollTop = logControl.scrollHeight;
        }
        function connect() {
          disconnect();
@@ -62,17 +67,17 @@
        }
        function update_ui() {
          if (conn == null) {
-           $('#status').text('disconnected');
-           $('#connect').html('Connect');
-           $('#send').prop("disabled", true);
+           status.textContent = 'disconnected';
+           connectButton.textContent = 'Connect';
+           sendButton.disabled = true;
          } else {
-           $('#status').text('connected (' + conn.protocol + ')');
-           $('#connect').html('Disconnect');
-           $('#send').prop("disabled", false);
+           status.textContent = 'connected (' + conn.protocol + ')';
+           connectButton.textContent = 'Disconnect';
+           sendButton.disabled = false;
          }
-         $('#name').text(name);
+         nameLabel.textContent = name;
        }
-       $('#connect').on('click', function() {
+       connectButton.addEventListener('click', function() {
          if (conn == null) {
            connect();
          } else {
@@ -81,17 +86,18 @@
          update_ui();
          return false;
        });
-       $('#send').on('click', function() {
-         var text = $('#text').val();
+       sendButton.addEventListener('click', function() {
+         var text = textInput.value;
          // log('Sending: ' + text);
          log(text);
          conn.send(text);
-         $('#text').val('').focus();
+         textInput.value = '';
+         textInput.focus();
          return false;
        });
-       $('#text').on('keyup', function(e) {
+       textInput.addEventListener('keyup', function(e) {
          if (e.keyCode === 13) {
-           $('#send').click();
+           sendButton.click();
            return false;
          }
        });

--- a/demos/chat/tests/test_chat.py
+++ b/demos/chat/tests/test_chat.py
@@ -14,3 +14,15 @@ async def test_msg_sending(client):
 
     assert set(received_dict) == {'action', 'name', 'text'}
     assert received_dict['text'] == text_to_send
+
+
+async def test_chat_page_does_not_use_jquery_or_html_insertion(client):
+    resp = await client.get('/')
+    assert resp.status == 200
+
+    page = await resp.text()
+
+    assert 'jquery' not in page
+    assert 'ajax.googleapis.com' not in page
+    assert '.html(' not in page
+    assert 'createTextNode' in page


### PR DESCRIPTION
## What changed

Removed the external jQuery dependency from the chat demo and replaced the template JavaScript with native DOM APIs.

The chat log now appends messages as text nodes instead of appending HTML, so chat message content is not interpreted as markup.

## Validation

- `.venv/bin/python -m pytest demos/chat`
- `.venv/bin/python -m flake8 demos/chat`
- `git diff --check`
- Manual browser check: connect, send, receive, and disconnect still work. Markup-looking chat text is rendered as text.

Full repo lint was also checked with `.venv/bin/python -m flake8 demos`; it currently fails on an unrelated existing warning in `demos/moderator/moderator/exceptions.py`.
