### PR TITLE
chat: validate Origin header on websocket handshake

### DIFF
--- a/demos/chat/aiohttpdemo_chat/views.py
+++ b/demos/chat/aiohttpdemo_chat/views.py
@@ -1,4 +1,5 @@
 import logging
+from urllib.parse import urlsplit
 
 import aiohttp
 import aiohttp_jinja2
@@ -20,6 +21,14 @@ async def index(request):
     ws_ready = ws_current.can_prepare(request)
     if not ws_ready.ok:
         return aiohttp_jinja2.render_template('index.html', request, {})
+
+    # Reject cross-site WebSocket hijacking: if the browser sent an Origin
+    # header, it must match the request host. Non-browser clients (which
+    # typically do not send Origin) are allowed through unchanged.
+    origin = request.headers.get('Origin')
+    if origin is not None and urlsplit(origin).netloc != request.host:
+        raise web.HTTPForbidden(
+            reason='Cross-origin WebSocket connection rejected')
 
     await ws_current.prepare(request)
 

--- a/demos/chat/tests/test_chat.py
+++ b/demos/chat/tests/test_chat.py
@@ -41,9 +41,6 @@ async def test_ws_rejects_cross_origin(client):
 
 async def test_ws_accepts_same_origin(client):
     origin = f'http://{client.host}:{client.port}'
-    ws = await client.ws_connect('/', headers={'Origin': origin})
-    try:
+    async with await client.ws_connect('/', headers={'Origin': origin}) as ws:
         msg = await ws.receive()
         assert msg.json()['action'] == 'connect'
-    finally:
-        await ws.close()

--- a/demos/chat/tests/test_chat.py
+++ b/demos/chat/tests/test_chat.py
@@ -1,3 +1,7 @@
+import aiohttp
+import pytest
+
+
 async def test_msg_sending(client):
     ws1 = await client.ws_connect('/')
     ws2 = await client.ws_connect('/')
@@ -26,3 +30,20 @@ async def test_chat_page_does_not_use_jquery_or_html_insertion(client):
     assert 'ajax.googleapis.com' not in page
     assert '.html(' not in page
     assert 'createTextNode' in page
+
+
+async def test_ws_rejects_cross_origin(client):
+    with pytest.raises(aiohttp.WSServerHandshakeError) as exc_info:
+        await client.ws_connect(
+            '/', headers={'Origin': 'http://evil.example'})
+    assert exc_info.value.status == 403
+
+
+async def test_ws_accepts_same_origin(client):
+    origin = f'http://{client.host}:{client.port}'
+    ws = await client.ws_connect('/', headers={'Origin': origin})
+    try:
+        msg = await ws.receive()
+        assert msg.json()['action'] == 'connect'
+    finally:
+        await ws.close()


### PR DESCRIPTION
## What changed

The chat demo's websocket handler now checks the `Origin` header before completing the upgrade. If a client sends an `Origin` header that does not match the request host, the handshake is rejected with `403 Forbidden`. Clients that do not send an `Origin` header (e.g. non-browser clients) continue to work unchanged, so the existing `pytest-aiohttp` test client and any scripted consumers are not affected.

This brings the chat demo in line with the same-origin assumption documented in the README (the demo is meant to be opened at `http://127.0.0.1:8080`) and avoids a browser on another origin opening a connection to a locally-running instance.

## Validation

- `.venv/bin/python -m pytest demos/chat` — all 4 tests pass, including the two new ones:
  - `test_ws_rejects_cross_origin` — expects `WSServerHandshakeError` with status 403 when `Origin: http://evil.example` is sent.
  - `test_ws_accepts_same_origin` — sends `Origin: http://{client.host}:{client.port}` and expects a successful `connect` frame.
- `.venv/bin/python -m flake8 demos/chat` — clean.
- Existing tests (`test_msg_sending`, `test_chat_page_does_not_use_jquery_or_html_insertion`) continue to pass without modification.

## Notes

The check uses `urllib.parse.urlsplit(origin).netloc` compared against `request.host`. Non-browser clients are intentionally not blocked because they typically omit `Origin`; the goal is to block browser-initiated cross-origin connections, where browsers always set `Origin` on the WebSocket handshake.