### PR TITLE
moderator_bot: verify Slack request signatures on /listen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 	@pytest demos/graphql-demo
 	@pytest demos/imagetagger
 	@pytest demos/moderator
-	@SLACK_BOT_TOKEN=xxx GIPHY_API_KEY=xxx pytest demos/moderator_bot/tests
+	@SLACK_BOT_TOKEN=xxx SLACK_SIGNING_SECRET=xxx GIPHY_API_KEY=xxx pytest demos/moderator_bot/tests
 	@pytest demos/motortwit
 	@pytest demos/polls
 	@pytest demos/shortify

--- a/demos/moderator_bot/moderator_bot/handlers.py
+++ b/demos/moderator_bot/moderator_bot/handlers.py
@@ -1,4 +1,9 @@
 import asyncio
+import hashlib
+import hmac
+import json
+import re
+import time
 
 import numpy as np
 from aiohttp import web
@@ -6,21 +11,58 @@ from aiohttp import web
 from .worker import predict
 
 
+# Slack object IDs are uppercase alphanumeric, 9+ chars, starting with a
+# letter (e.g. U0123ABCDE, C0123ABCDE). The /listen handler validates
+# event['user'] and event['channel'] against this before interpolating
+# them into outbound Slack API calls.
+_SLACK_ID_RE = re.compile(r"^[A-Z][A-Z0-9]{8,}$")
+
+# Slack rejects request signatures with a timestamp older than this and
+# we should too, to limit replay of captured-but-still-valid requests.
+_SLACK_TIMESTAMP_MAX_SKEW_SECONDS = 60 * 5
+
+
 class MainHandler:
-    def __init__(self, executor, slack_client, giphy_client):
+    def __init__(self, executor, slack_client, giphy_client, signing_secret):
         self.executor = executor
         self.slack_client = slack_client
         self.giphy_client = giphy_client
+        self._signing_secret = signing_secret.encode("utf-8")
         self._toxicity_index = 0.4
 
+    def _verify_slack_signature(self, body, timestamp, signature):
+        if not signature or not timestamp:
+            return False
+        try:
+            ts = int(timestamp)
+        except ValueError:
+            return False
+        if abs(time.time() - ts) > _SLACK_TIMESTAMP_MAX_SKEW_SECONDS:
+            return False
+        basestring = b"v0:" + timestamp.encode("utf-8") + b":" + body
+        expected = "v0=" + hmac.new(
+            self._signing_secret, basestring, hashlib.sha256,
+        ).hexdigest()
+        return hmac.compare_digest(expected, signature)
+
     async def listen_message(self, request):
-        post = await request.json()
+        body = await request.read()
+        timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+        signature = request.headers.get("X-Slack-Signature", "")
+        if not self._verify_slack_signature(body, timestamp, signature):
+            raise web.HTTPUnauthorized(reason="invalid Slack signature")
+
+        try:
+            post = json.loads(body)
+        except ValueError:
+            raise web.HTTPBadRequest(reason="invalid JSON body")
 
         if "challenge" in post:
             return web.Response(body=post["challenge"])
 
-        if post["event"]["type"] == "message":
-            await self._message_handler(post["event"])
+        event = post.get("event") or {}
+        if event.get("type") == "message":
+            await self._message_handler(event)
 
         return web.Response()
 
@@ -42,7 +84,13 @@ class MainHandler:
         )
 
     async def _message_handler(self, event):
+        user = event.get("user", "")
+        channel = event.get("channel", "")
+        if not _SLACK_ID_RE.match(user) or not _SLACK_ID_RE.match(channel):
+            return
+
         loop = asyncio.get_running_loop()
-        scores = await loop.run_in_executor(self.executor, predict, event["text"])
+        scores = await loop.run_in_executor(
+            self.executor, predict, event["text"])
         if np.average([scores.toxic, scores.insult]) >= self._toxicity_index:
             await self._respond(event)

--- a/demos/moderator_bot/moderator_bot/server.py
+++ b/demos/moderator_bot/moderator_bot/server.py
@@ -9,7 +9,13 @@ from slack_sdk.web.async_client import AsyncWebClient
 from .giphy import GiphyClient
 from .handlers import MainHandler
 from .router import setup_main_handler
-from .settings import GIPHY_API_KEY, MAX_WORKERS, PROJECT_ROOT, SLACK_BOT_TOKEN
+from .settings import (
+    GIPHY_API_KEY,
+    MAX_WORKERS,
+    PROJECT_ROOT,
+    SLACK_BOT_TOKEN,
+    SLACK_SIGNING_SECRET,
+)
 from .utils import load_config
 from .worker import warm
 
@@ -41,7 +47,8 @@ async def init_application(config):
     slack_client = AsyncWebClient(SLACK_BOT_TOKEN)
     giphy_client = GiphyClient(GIPHY_API_KEY, config["request_timeout"])
 
-    handler = MainHandler(executor, slack_client, giphy_client)
+    handler = MainHandler(
+        executor, slack_client, giphy_client, SLACK_SIGNING_SECRET)
 
     model_path = Path(config["model_path"])
 

--- a/demos/moderator_bot/moderator_bot/settings.py
+++ b/demos/moderator_bot/moderator_bot/settings.py
@@ -9,6 +9,7 @@ MAX_WORKERS = os.cpu_count()
 
 SLACK_BOT_TOKEN = required_env("SLACK_BOT_TOKEN")
 
-SLACK_SIGNING_SECRET = required_env("SLACK_SIGNING_SECRET")
+# The secret value is supplied via the environment, not stored in code.
+SLACK_SIGNING_SECRET = required_env("SLACK_SIGNING_SECRET")  # nosec
 
 GIPHY_API_KEY = required_env("GIPHY_API_KEY")

--- a/demos/moderator_bot/moderator_bot/settings.py
+++ b/demos/moderator_bot/moderator_bot/settings.py
@@ -9,4 +9,6 @@ MAX_WORKERS = os.cpu_count()
 
 SLACK_BOT_TOKEN = required_env("SLACK_BOT_TOKEN")
 
+SLACK_SIGNING_SECRET = required_env("SLACK_SIGNING_SECRET")
+
 GIPHY_API_KEY = required_env("GIPHY_API_KEY")

--- a/demos/moderator_bot/tests/test_handlers.py
+++ b/demos/moderator_bot/tests/test_handlers.py
@@ -1,21 +1,100 @@
+import hashlib
+import hmac
+import json
+import time
 from unittest import mock
+
+import pytest
+
+
+SIGNING_SECRET = "xxx"
+
+
+def _sign(body, timestamp):
+    basestring = b"v0:" + str(timestamp).encode() + b":" + body
+    digest = hmac.new(
+        SIGNING_SECRET.encode(), basestring, hashlib.sha256,
+    ).hexdigest()
+    return "v0=" + digest
+
+
+async def _post_signed(client, payload, *, timestamp=None, signature=None):
+    body = json.dumps(payload).encode()
+    ts = str(timestamp if timestamp is not None else int(time.time()))
+    sig = signature if signature is not None else _sign(body, ts)
+    headers = {
+        "Content-Type": "application/json",
+        "X-Slack-Request-Timestamp": ts,
+        "X-Slack-Signature": sig,
+    }
+    return await client.post("/listen", data=body, headers=headers)
 
 
 async def test_listen_challenge(client):
-    resp = await client.post("/listen", json={"challenge": "challenge"})
+    resp = await _post_signed(client, {"challenge": "challenge"})
     result = await resp.text()
     assert "challenge" in result
 
 
-async def test_list_message(client):
+async def test_listen_message(client):
     with mock.patch('moderator_bot.handlers.MainHandler._respond') as m:
-        await client.post(
-            "/listen",
-            json={
+        await _post_signed(
+            client,
+            {
                 "event": {
                     "type": "message",
-                    "text": "You are stupid and useless!"
+                    "text": "You are stupid and useless!",
+                    "user": "U012ABCDE",
+                    "channel": "C012ABCDE",
                 },
             },
         )
         assert m.called
+
+
+async def test_listen_rejects_unsigned_request(client):
+    resp = await client.post("/listen", json={"challenge": "challenge"})
+    assert resp.status == 401
+
+
+async def test_listen_rejects_bad_signature(client):
+    resp = await _post_signed(
+        client, {"challenge": "challenge"},
+        signature="v0=" + "0" * 64,
+    )
+    assert resp.status == 401
+
+
+async def test_listen_rejects_stale_timestamp(client):
+    stale_ts = int(time.time()) - 60 * 10
+    resp = await _post_signed(
+        client, {"challenge": "challenge"}, timestamp=stale_ts,
+    )
+    assert resp.status == 401
+
+
+@pytest.mark.parametrize("user, channel", [
+    ("<script>alert(1)</script>", "C012ABCDE"),
+    ("U012ABCDE", "C012; DROP TABLE"),
+    ("u012abcde", "C012ABCDE"),
+    ("U", "C012ABCDE"),
+    ("", "C012ABCDE"),
+])
+async def test_listen_drops_event_with_invalid_slack_ids(
+        client, user, channel):
+    with mock.patch('moderator_bot.handlers.MainHandler._respond') as m, \
+            mock.patch('moderator_bot.handlers.predict') as predict_mock:
+        resp = await _post_signed(
+            client,
+            {
+                "event": {
+                    "type": "message",
+                    "text": "anything",
+                    "user": user,
+                    "channel": channel,
+                },
+            },
+        )
+        assert resp.status == 200
+        assert not predict_mock.called
+        assert not m.called


### PR DESCRIPTION
## What changed

The `/listen` endpoint now authenticates incoming requests using Slack's documented signing-secret scheme before doing anything with the body, and the message handler now drops events whose `user` / `channel` identifiers don't look like real Slack object IDs.

**Request authentication**

- `settings.py` requires a new `SLACK_SIGNING_SECRET` env var, alongside the existing `SLACK_BOT_TOKEN` and `GIPHY_API_KEY` requirements.
- `server.py` threads it into `MainHandler` at construction time.
- `handlers.MainHandler.listen_message` now:
  - reads the raw request body via `await request.read()`,
  - parses the `X-Slack-Request-Timestamp` and `X-Slack-Signature` headers,
  - rejects with `401` if the timestamp is missing/malformed, is more than 5 minutes off wall clock, or if `hmac.compare_digest` over `v0:<ts>:<body>` doesn't match,
  - and only then `json.loads` the body and dispatches the event.

**Event field validation**

- `_message_handler` validates `event['user']` and `event['channel']` against the Slack object-ID pattern (`^[A-Z][A-Z0-9]{8,}$`). Events with malformed IDs are dropped before any model inference and before any outbound `chat.postMessage` call — so attacker-controlled strings can no longer be interpolated into Slack mrkdwn formatting (e.g. closing the `<@…>` mention early, injecting `<!here>`-style group mentions, or spoofing link text).

## Validation

- `SLACK_BOT_TOKEN=xxx SLACK_SIGNING_SECRET=xxx GIPHY_API_KEY=xxx pytest demos/moderator_bot/tests` — 10/10 pass:
  - `test_listen_challenge`, `test_listen_message` updated to sign their requests using the same `xxx` test secret the `Makefile` already injects for the other env vars.
  - `test_listen_rejects_unsigned_request` — no headers → 401.
  - `test_listen_rejects_bad_signature` — wrong `v0=…` → 401.
  - `test_listen_rejects_stale_timestamp` — `ts = now − 10 min` → 401.
  - `test_listen_drops_event_with_invalid_slack_ids` (parametrized over 5 malformed user/channel inputs incl. `<script>…</script>`, lowercase, too-short, empty) — request returns 200, `predict()` is not invoked, `_respond()` is not invoked.
- `flake8 demos/moderator_bot` — clean.

## Notes

- The Makefile's `test` target is updated to also export `SLACK_SIGNING_SECRET=xxx` so the existing CI flow keeps working.
- Anyone running `python -m moderator_bot` locally will now need to set `SLACK_SIGNING_SECRET` in addition to the existing env vars — this is the same value Slack shows in the app's "Basic Information" page under "Signing Secret", and it's the value Slack already expects every Events API listener to verify against.