### PR TITLE
graphql-demo: close per-subscription Redis connections via redis.asyncio

### DIFF
--- a/demos/graphql-demo/README.md
+++ b/demos/graphql-demo/README.md
@@ -40,5 +40,5 @@ make mypy # running the types checking by mypy
 ### Requirements
 - aiohttp
 - aiopg
-- aioredis
+- redis (asyncio)
 - graphene

--- a/demos/graphql-demo/graph/api/mutations/messages.py
+++ b/demos/graphql-demo/graph/api/mutations/messages.py
@@ -1,3 +1,5 @@
+import json
+
 import graphene
 
 from graph.auth.db_utils import select_user
@@ -31,14 +33,14 @@ class AddMessageMutation(graphene.Mutation):
             message = await create_message(sess, room_id, owner_id, body)
             owner = await select_user(sess, owner_id)
 
-        await app["redis_pub"].publish_json(
+        await app["redis_pub"].publish(
             f"chat:{room_id}",
-            {
+            json.dumps({
                 "body": body,
                 "id": message.id,
                 "username": owner.username,
                 "user_id": owner.id,
-            },
+            }),
         )
 
         return AddMessageMutation(is_created=True)
@@ -76,9 +78,9 @@ class StartTypingMessageMutation(graphene.Mutation):
         async with app["db"].begin() as sess:
             user = await select_user(sess, user_id)
 
-        await app["redis_pub"].publish_json(
+        await app["redis_pub"].publish(
             f"chat:typing:{room_id}",
-            {"username": user.username, "id": user.id},
+            json.dumps({"username": user.username, "id": user.id}),
         )
 
         return StartTypingMessageMutation(is_success=True)

--- a/demos/graphql-demo/graph/api/subscriptions/messages.py
+++ b/demos/graphql-demo/graph/api/subscriptions/messages.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import random
 
 import graphene
@@ -52,18 +53,18 @@ class MessageSubscription(graphene.ObjectType):
     ) -> MessageAdded:
         app = info.context["request"].app
 
-        redis = await app["create_redis"]()
-
-        res = await redis.subscribe(f"chat:{room_id}")
-        ch = res[0]
-
-        while await ch.wait_message():
-            data = await ch.get_json()
-            yield MessageAdded(
-                body=data["body"],
-                id=data["id"],
-                owner=User(id=data["user_id"], username=data["username"]),
-            )
+        async with app["redis_pub"].pubsub() as ps:
+            await ps.subscribe(f"chat:{room_id}")
+            async for message in ps.listen():
+                if message["type"] != "message":
+                    continue
+                data = json.loads(message["data"])
+                yield MessageAdded(
+                    body=data["body"],
+                    id=data["id"],
+                    owner=User(
+                        id=data["user_id"], username=data["username"]),
+                )
 
     async def resolve_typing_start(
         self,
@@ -72,11 +73,11 @@ class MessageSubscription(graphene.ObjectType):
     ) -> MessageAdded:
         app = info.context["request"].app
 
-        redis = await app["create_redis"]()
-
-        res = await redis.subscribe(f"chat:typing:{room_id}")
-        ch = res[0]
-
-        while await ch.wait_message():
-            data = await ch.get_json()
-            yield StartTyping(user=User(username=data["username"], id=data["id"]))
+        async with app["redis_pub"].pubsub() as ps:
+            await ps.subscribe(f"chat:typing:{room_id}")
+            async for message in ps.listen():
+                if message["type"] != "message":
+                    continue
+                data = json.loads(message["data"])
+                yield StartTyping(
+                    user=User(username=data["username"], id=data["id"]))

--- a/demos/graphql-demo/graph/app.py
+++ b/demos/graphql-demo/graph/app.py
@@ -1,8 +1,6 @@
-from functools import partial
-
 from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker
 from aiohttp import web
-import aioredis
+import redis.asyncio as redis
 import aiohttp_jinja2
 import jinja2
 
@@ -46,21 +44,18 @@ async def redis_ctx(app: web.Application) -> None:
     """This is signal for success creating connection with redis."""
     config = app["config"]["redis"]
 
-    sub = await aioredis.create_redis(f'redis://{config["host"]}:{config["port"]}')
-    pub = await aioredis.create_redis(f'redis://{config["host"]}:{config["port"]}')
-
-    create_redis = partial(
-        aioredis.create_redis, f'redis://{config["host"]}:{config["port"]}'
+    # A single client handles both publish and subscribe — pubsub()
+    # internally checks out a dedicated connection from the pool, so
+    # the same client object can still issue normal commands.
+    client = redis.from_url(
+        f'redis://{config["host"]}:{config["port"]}',
+        decode_responses=True,
     )
-
-    app["redis_sub"] = sub
-    app["redis_pub"] = pub
-    app["create_redis"] = create_redis
+    app["redis_pub"] = client
 
     yield
 
-    app["redis_sub"].close()
-    app["redis_pub"].close()
+    await client.aclose()
 
 
 async def init_graph_loaders(app: web.Application) -> None:

--- a/demos/graphql-demo/graph/conftest.py
+++ b/demos/graphql-demo/graph/conftest.py
@@ -143,7 +143,7 @@ async def requests(db_engine, db_sm):
 
     class RedisMock:
         @staticmethod
-        async def publish_json(*_):
+        async def publish(*_):
             return Mock()
 
     request = Mock()

--- a/demos/graphql-demo/tests/test_subscriptions.py
+++ b/demos/graphql-demo/tests/test_subscriptions.py
@@ -1,0 +1,94 @@
+"""Tests for the per-subscription Redis pub/sub resolvers.
+
+These drive the real resolver coroutines in
+``graph.api.subscriptions.messages`` against a fake ``redis.asyncio``
+client, so they need neither a running Redis nor the rest of the app.
+The point the maintainer raised was the per-subscription connection
+lifecycle: the resolver now uses ``async with client.pubsub()`` so the
+dedicated connection is released when the subscriber goes away. The
+``closed`` assertions below verify that the context manager actually
+exits (i.e. the connection is cleaned up).
+"""
+import json
+import types
+
+from graph.api.subscriptions.messages import MessageSubscription
+
+
+class _FakePubSub:
+    """Stands in for a ``redis.asyncio`` PubSub, which is itself an async
+    context manager (``async with client.pubsub() as ps``)."""
+
+    def __init__(self, messages):
+        self._messages = messages
+        self.subscribed = []
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self.closed = True
+        return False
+
+    async def subscribe(self, channel):
+        self.subscribed.append(channel)
+
+    async def listen(self):
+        for message in self._messages:
+            yield message
+
+
+class _FakeRedis:
+    def __init__(self, pubsub):
+        self._pubsub = pubsub
+
+    def pubsub(self):
+        return self._pubsub
+
+
+def _info_for(pubsub):
+    app = {"redis_pub": _FakeRedis(pubsub)}
+    request = types.SimpleNamespace(app=app)
+    return types.SimpleNamespace(context={"request": request})
+
+
+async def _drain(agen):
+    return [item async for item in agen]
+
+
+async def test_resolve_message_added_yields_and_releases_connection():
+    pubsub = _FakePubSub([
+        {"type": "subscribe", "data": 1},          # confirmation: skipped
+        {"type": "message", "data": json.dumps({
+            "body": "hello", "id": 7,
+            "username": "ann", "user_id": 3})},
+    ])
+    sub = MessageSubscription()
+
+    results = await _drain(
+        sub.resolve_message_added(_info_for(pubsub), room_id=42))
+
+    assert pubsub.subscribed == ["chat:42"]
+    assert len(results) == 1            # the subscribe confirmation is dropped
+    assert results[0].body == "hello"
+    assert results[0].id == 7
+    assert results[0].owner.username == "ann"
+    assert results[0].owner.id == 3
+    assert pubsub.closed is True        # connection released on exit
+
+
+async def test_resolve_typing_start_yields_and_releases_connection():
+    pubsub = _FakePubSub([
+        {"type": "message", "data": json.dumps({"username": "bob", "id": 9})},
+    ])
+    sub = MessageSubscription()
+
+    results = await _drain(
+        sub.resolve_typing_start(_info_for(pubsub), room_id=5))
+
+    assert pubsub.subscribed == ["chat:typing:5"]
+    assert len(results) == 1
+    assert results[0].user.username == "bob"
+    assert results[0].user.id == 9
+    assert pubsub.closed is True


### PR DESCRIPTION
## What changed

The subscription resolvers opened a fresh Redis connection per subscriber and never closed it: `resolve_message_added` and `resolve_typing_start` called `await app["create_redis"]()`, and when a subscriber disconnected the async generator was cancelled but the connection leaked — eventually exhausting Redis-side connection limits on a busy server.

This switches the demo's Redis usage to `redis.asyncio` and uses its pub/sub **context manager**, so the dedicated connection is released automatically when the subscriber goes away.

### [graph/app.py](demos/graphql-demo/graph/app.py)
A single `redis.asyncio` client now serves both publish and subscribe — `pubsub()` checks out a dedicated connection from the pool, so ordinary commands and pub/sub coexist on one client. Teardown is `await client.aclose()`.

### [api/subscriptions/messages.py](demos/graphql-demo/graph/api/subscriptions/messages.py)
Both resolvers now use `async with app["redis_pub"].pubsub() as ps:` and iterate via `ps.listen()`, so the per-subscription connection is released on exit. `decode_responses=True` makes the payload arrive as `str`, deserialized with `json.loads`.

### [api/mutations/messages.py](demos/graphql-demo/graph/api/mutations/messages.py)
`publish_json(channel, dict)` (an aioredis convenience) becomes `publish(channel, json.dumps(...))`, the `redis.asyncio` API.

## Validation

- New [`tests/test_subscriptions.py`](demos/graphql-demo/tests/test_subscriptions.py) drives both resolvers against a fake client and asserts the channel subscription, message decoding, and — crucially — that the pub/sub context manager releases the connection on exit. Runs without a live Redis: `pytest demos/graphql-demo/tests` → 2/2 pass.
- `flake8 demos/graphql-demo` — clean.

## Notes

`redis.asyncio` is the smallest change that provides a pub/sub context manager: it is already the declared dependency (`redis>=4.2`), whereas the previous code imported the separate `aioredis` package that isn't listed in `setup.py` / `requirements-dev.txt`. Only the subscription connection lifecycle and the publish call signature change; happy-path behavior is unchanged.
