### PR TITLE
imagetagger: fix broken "Fork me on GitHub" ribbon

### DIFF
--- a/demos/imagetagger/imagetagger/static/styles/main.css
+++ b/demos/imagetagger/imagetagger/static/styles/main.css
@@ -68,30 +68,6 @@ main {
     width: 100%;
 }
 
-/* github link */
-
-.fork-me-on-github {
-    position: absolute;
-    top: 40px;
-    right: -55px;
-    width: 200px;
-    padding: 6px 0;
-    color: #fff;
-    font-size: 13px;
-    font-weight: bold;
-    text-align: center;
-    text-decoration: none;
-    background: #121621;
-    border-top: 1px dashed rgba(255, 255, 255, 0.4);
-    border-bottom: 1px dashed rgba(255, 255, 255, 0.4);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
-    transform: rotate(45deg);
-}
-
-.fork-me-on-github:hover {
-    background: #1c2030;
-}
-
 /* common */
 .btn {
     display: inline-block;

--- a/demos/imagetagger/imagetagger/static/styles/main.css
+++ b/demos/imagetagger/imagetagger/static/styles/main.css
@@ -72,8 +72,24 @@ main {
 
 .fork-me-on-github {
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 40px;
+    right: -55px;
+    width: 200px;
+    padding: 6px 0;
+    color: #fff;
+    font-size: 13px;
+    font-weight: bold;
+    text-align: center;
+    text-decoration: none;
+    background: #121621;
+    border-top: 1px dashed rgba(255, 255, 255, 0.4);
+    border-bottom: 1px dashed rgba(255, 255, 255, 0.4);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
+    transform: rotate(45deg);
+}
+
+.fork-me-on-github:hover {
+    background: #1c2030;
 }
 
 /* common */

--- a/demos/imagetagger/imagetagger/templates/index.html
+++ b/demos/imagetagger/imagetagger/templates/index.html
@@ -16,9 +16,6 @@
 </head>
 <body>
     <header class="header">
-        <a href="https://github.com/Arfey/create-aio-app" class="fork-me-on-github">
-            Fork me on GitHub
-        </a>
         <div class="banner">
             <img
                 class="banner-logo"

--- a/demos/imagetagger/imagetagger/templates/index.html
+++ b/demos/imagetagger/imagetagger/templates/index.html
@@ -17,10 +17,7 @@
 <body>
     <header class="header">
         <a href="https://github.com/Arfey/create-aio-app" class="fork-me-on-github">
-            <img
-                src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png"
-                alt="Fork me on GitHub"
-            >
+            Fork me on GitHub
         </a>
         <div class="banner">
             <img


### PR DESCRIPTION
## What changed

Replaced the broken "Fork me on GitHub" ribbon image in the imagetagger demo. The previous `<img>` pointed at `https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png`, which now returns `403 Forbidden` — GitHub retired the S3-hosted ribbon PNGs years ago.

The fix swaps the broken external image for a self-contained CSS ribbon (rotated dark-blue banner), so the corner link renders without any external asset and can't break again.

## Validation

- Confirmed the old URL is dead: `curl -I https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png` → `HTTP/1.1 403 Forbidden`.
- Rendered the modified `index.html` (with `static/...` paths substituted for the Jinja `url()` calls) in a local static preview and visually confirmed the dark CSS ribbon appears in the top-right corner with "Fork me on GitHub" text and the original link target.
- Did not run the full aiohttp app (would require installing tensorflow+keras) — the change is HTML/CSS only with no server-side behavior.